### PR TITLE
More portable shebang

### DIFF
--- a/ktoolbox
+++ b/ktoolbox
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 name=${KTOOLBOX_NAME:-toolbox-${USER}}


### PR DESCRIPTION
Because not everyone has `bash` in `/bin` :)